### PR TITLE
Fix. IncompleteRead: urllib is more "reliable" now

### DIFF
--- a/od_import/protocol_handlers/http/directory_of.py
+++ b/od_import/protocol_handlers/http/directory_of.py
@@ -20,6 +20,8 @@ from urllib.error import (
     URLError
 )
 
+import requests
+
 ########################## link parser ###############################
 
 class LinkScrape(HTMLParser):
@@ -112,7 +114,7 @@ def directory_of(url, path="", path_cache: list=[], cache_update: bool=True, con
         url = f"{urlsplit[0]}://{creds}{urlsplit[1]}"
     if path:
         url = "/".join([url, path])
-    resp = opener(url).read()
+    resp = requests.get(url).content
     if cache_update:
         try:
             # attempt to parse links on the page

--- a/od_import/protocol_handlers/http/directory_of.py
+++ b/od_import/protocol_handlers/http/directory_of.py
@@ -122,21 +122,20 @@ def directory_of(url, path="", path_cache: list=[], cache_update: bool=True, con
     if path:
         url = "/".join([url, path])
 
-    e = None
     for attemps in range(GET_FILE_MAX_ATTEMPTS):
         try:
             resp = opener(url).read()
             break
         except IncompleteRead as e:
             logging.info(e)
+            if attemps == GET_FILE_MAX_ATTEMPTS - 1:
+                raise e
 
         try:
             time.sleep(GET_FILE_MAX_WAIT)
-        except OSError as e: # Sometimes sleep raises an OSError
+        except OSError as e:
             logging.error(e)
             continue
-    else:
-        raise e
 
     if cache_update:
         try:

--- a/od_import/protocol_handlers/http/directory_of.py
+++ b/od_import/protocol_handlers/http/directory_of.py
@@ -124,7 +124,6 @@ def directory_of(url, path="", path_cache: list=[], cache_update: bool=True, con
 
     e = None
     for attemps in range(GET_FILE_MAX_ATTEMPTS):
-        
         try:
             resp = opener(url).read()
             break

--- a/od_import/protocol_handlers/http/directory_of.py
+++ b/od_import/protocol_handlers/http/directory_of.py
@@ -7,9 +7,6 @@ from html.parser import HTMLParser
 GET_FILE_MAX_ATTEMPTS = 3
 GET_FILE_MAX_WAIT = 0.5
 
-threedotoh = (sys.version_info.major == 3 and sys.version_info.minor < 4)
-threedotfour = (sys.version_info.major == 3 and sys.version_info.minor >= 4)
-
 from urllib.request import (
     urlopen,
     Request,

--- a/od_import/protocol_handlers/http/directory_of.py
+++ b/od_import/protocol_handlers/http/directory_of.py
@@ -18,7 +18,7 @@ from urllib.request import (
 )
 from urllib.error import (
     HTTPError,
-    URLError,
+    URLError
 )
 
 try:
@@ -127,7 +127,7 @@ def directory_of(url, path="", path_cache: list=[], cache_update: bool=True, con
     if path:
         url = "/".join([url, path])
 
-    for attempt in range(GET_FILE_MAX_ATTEMPTS):  # Cambia 5 al número de intentos que deseas realizar
+    for attempt in range(GET_FILE_MAX_ATTEMPTS):
         if not requests:
             try:
                 resp = opener(url).read()


### PR DESCRIPTION
Improved method for download

```
GET_FILE_MAX_ATTEMPTS = 3
GET_FILE_MAX_WAIT = 0.5
```

```
try:
    from httplib import IncompleteRead
except ImportError:
    from http.client import IncompleteRead
```

```
    for attemps in range(GET_FILE_MAX_ATTEMPTS):
        try:
            resp = opener(url).read()
            break
        except IncompleteRead as e:
            logging.info(e)
            if attemps == GET_FILE_MAX_ATTEMPTS - 1:
                raise e

        try:
            time.sleep(GET_FILE_MAX_WAIT)
        except OSError as e:
            logging.error(e)
            continue
```

That solves: Incomplete reading, a very common error, even in stable connections.